### PR TITLE
Explicitly initialize backing stores in constructors

### DIFF
--- a/src/main/java/io/github/brevilo/jolm/Account.java
+++ b/src/main/java/io/github/brevilo/jolm/Account.java
@@ -30,9 +30,8 @@ import io.github.brevilo.jolm.model.OneTimeKeys;
 /** Class to represent an Olm account. */
 public class Account {
 
-  /** Account backing store. */
-  public final OlmAccount instance =
-      Utils.initialize(OlmLibrary::olm_account, OlmLibrary::olm_account_size);
+  // backing store
+  public final OlmAccount instance;
 
   private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -42,6 +41,9 @@ public class Account {
    * @throws OlmException <code>NOT_ENOUGH_RANDOM</code> if there weren't enough random bytes
    */
   public Account() throws OlmException {
+    // initialize account backing store
+    instance = Utils.initialize(OlmLibrary::olm_account, OlmLibrary::olm_account_size);
+
     // canonical JSON
     objectMapper.configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
 

--- a/src/main/java/io/github/brevilo/jolm/InboundGroupSession.java
+++ b/src/main/java/io/github/brevilo/jolm/InboundGroupSession.java
@@ -27,13 +27,16 @@ import io.github.brevilo.jolm.model.GroupMessage;
 /** Class to represent an inbound Megolm session. */
 public class InboundGroupSession {
 
-  /** InboundGroupSession backing store. */
-  private final OlmInboundGroupSession instance =
-      Utils.initialize(
-          OlmLibrary::olm_inbound_group_session, OlmLibrary::olm_inbound_group_session_size);
+  // backing store
+  private final OlmInboundGroupSession instance;
 
-  /** Private constructor only used by {@link #unpickle(String, String)}. */
-  private InboundGroupSession() {}
+  /** Private constructor */
+  private InboundGroupSession() {
+    // initialize backing store
+    instance =
+        Utils.initialize(
+            OlmLibrary::olm_inbound_group_session, OlmLibrary::olm_inbound_group_session_size);
+  }
 
   /**
    * Creates a new inbound Megolm session using the provided session key. The key can be exported by
@@ -44,6 +47,9 @@ public class InboundGroupSession {
    *     <code>OLM_BAD_SESSION_KEY</code> if the sessionKey is invalid
    */
   public InboundGroupSession(String sessionKey) throws OlmException {
+    // call private constructor
+    this();
+
     // get native key
     Memory sessionKeyBuffer = Utils.toNative(sessionKey);
 

--- a/src/main/java/io/github/brevilo/jolm/OutboundGroupSession.java
+++ b/src/main/java/io/github/brevilo/jolm/OutboundGroupSession.java
@@ -25,10 +25,8 @@ import io.github.brevilo.jolm.jna.OlmOutboundGroupSession;
 /** Class to represent an outbound Megolm session. */
 public class OutboundGroupSession {
 
-  /** OutboundGroupSession backing store. */
-  private final OlmOutboundGroupSession instance =
-      Utils.initialize(
-          OlmLibrary::olm_outbound_group_session, OlmLibrary::olm_outbound_group_session_size);
+  // backing store
+  private final OlmOutboundGroupSession instance;
 
   /**
    * Creates a new outbound Megolm session initialized with random data.
@@ -36,6 +34,11 @@ public class OutboundGroupSession {
    * @throws OlmException <code>NOT_ENOUGH_RANDOM</code> if there weren't enough random bytes
    */
   public OutboundGroupSession() throws OlmException {
+    // initialize backing store
+    instance =
+        Utils.initialize(
+            OlmLibrary::olm_outbound_group_session, OlmLibrary::olm_outbound_group_session_size);
+
     // generate randomness and create session
     NativeSize randomLength = OlmLibrary.olm_init_outbound_group_session_random_length(instance);
     Memory randomBuffer = Utils.randomBuffer(randomLength);

--- a/src/main/java/io/github/brevilo/jolm/PkDecryption.java
+++ b/src/main/java/io/github/brevilo/jolm/PkDecryption.java
@@ -25,9 +25,9 @@ import io.github.brevilo.jolm.model.PkMessage;
 
 /** Class to represent an Olm decryption object. */
 public class PkDecryption {
-  /** Decryption object backing store. */
-  public final OlmPkDecryption instance =
-      Utils.initialize(OlmLibrary::olm_pk_decryption, OlmLibrary::olm_pk_decryption_size);
+
+  // backing store
+  public final OlmPkDecryption instance;
 
   private String publicKey;
 
@@ -38,6 +38,9 @@ public class PkDecryption {
    *     enough; <code>OUTPUT_BUFFER_TOO_SMALL</code> if the public key buffer was too small
    */
   public PkDecryption() throws OlmException {
+    // initialize backing store
+    instance = Utils.initialize(OlmLibrary::olm_pk_decryption, OlmLibrary::olm_pk_decryption_size);
+
     // generate random private key
     NativeSize privateKeyLength = OlmLibrary.olm_pk_private_key_length();
     Memory privateKeyBuffer = Utils.randomBuffer(privateKeyLength);

--- a/src/main/java/io/github/brevilo/jolm/PkEncryption.java
+++ b/src/main/java/io/github/brevilo/jolm/PkEncryption.java
@@ -26,9 +26,8 @@ import io.github.brevilo.jolm.model.PkMessage;
 /** Class to represent an Olm encryption object. */
 public class PkEncryption {
 
-  /** Encryption object backing store. */
-  public final OlmPkEncryption instance =
-      Utils.initialize(OlmLibrary::olm_pk_encryption, OlmLibrary::olm_pk_encryption_size);
+  // backing store
+  public final OlmPkEncryption instance;
 
   /**
    * Create a new encryption object for the given recipient key. The recepient's public key will be
@@ -38,6 +37,9 @@ public class PkEncryption {
    * @throws OlmException unspecified
    */
   public PkEncryption(String recipientKey) throws OlmException {
+    // initialize backing store
+    instance = Utils.initialize(OlmLibrary::olm_pk_encryption, OlmLibrary::olm_pk_encryption_size);
+
     // get native key
     Memory keyBuffer = Utils.toNative(recipientKey);
 

--- a/src/main/java/io/github/brevilo/jolm/PkSigning.java
+++ b/src/main/java/io/github/brevilo/jolm/PkSigning.java
@@ -26,9 +26,8 @@ import java.security.SecureRandom;
 /** Class to represent an Olm signing object. */
 public class PkSigning {
 
-  /** Signing object backing store. */
-  public final OlmPkSigning instance =
-      Utils.initialize(OlmLibrary::olm_pk_signing, OlmLibrary::olm_pk_signing_size);
+  // backing store
+  public final OlmPkSigning instance;
 
   private String publicKey;
 
@@ -42,6 +41,9 @@ public class PkSigning {
    *     <code>OUTPUT_BUFFER_TOO_SMALL</code> if the public key buffer is too small
    */
   public PkSigning(byte[] seed) throws OlmException {
+    // initialize backing store
+    instance = Utils.initialize(OlmLibrary::olm_pk_signing, OlmLibrary::olm_pk_signing_size);
+
     // get native seed
     Memory seedBuffer = new Memory(seed.length);
     seedBuffer.write(0, seed, 0, seed.length);

--- a/src/main/java/io/github/brevilo/jolm/Sas.java
+++ b/src/main/java/io/github/brevilo/jolm/Sas.java
@@ -25,8 +25,8 @@ import io.github.brevilo.jolm.jna.OlmSas;
 /** Class to represent an Olm short authentication string (SAS) object. */
 public class Sas {
 
-  /** SAS object backing store. */
-  public final OlmSas instance = Utils.initialize(OlmLibrary::olm_sas, OlmLibrary::olm_sas_size);
+  // backing store
+  public final OlmSas instance;
 
   /**
    * Creates a new SAS object.
@@ -34,6 +34,9 @@ public class Sas {
    * @throws OlmException <code>NOT_ENOUGH_RANDOM</code> if there weren't enough random bytes
    */
   public Sas() throws OlmException {
+    // initialize backing store
+    instance = Utils.initialize(OlmLibrary::olm_sas, OlmLibrary::olm_sas_size);
+
     // generate random private key
     NativeSize randomLength = OlmLibrary.olm_create_sas_random_length(instance);
     Memory randomBuffer = Utils.randomBuffer(randomLength);

--- a/src/main/java/io/github/brevilo/jolm/Session.java
+++ b/src/main/java/io/github/brevilo/jolm/Session.java
@@ -26,12 +26,14 @@ import io.github.brevilo.jolm.model.Message;
 /** Class to represent an Olm session. */
 public class Session {
 
-  /** Session backing store. */
-  public final OlmSession instance =
-      Utils.initialize(OlmLibrary::olm_session, OlmLibrary::olm_session_size);
+  // backing store
+  public final OlmSession instance;
 
   /** Private constructor. Use static create methods. */
-  private Session() {}
+  private Session() {
+    // initialize backing store
+    instance = Utils.initialize(OlmLibrary::olm_session, OlmLibrary::olm_session_size);
+  }
 
   /** Clears the memory used to back this session. */
   public void clear() {

--- a/src/main/java/io/github/brevilo/jolm/Utility.java
+++ b/src/main/java/io/github/brevilo/jolm/Utility.java
@@ -29,14 +29,16 @@ import io.github.brevilo.jolm.jna.OlmUtility;
 /** Class to provide libolm utility functions. */
 public class Utility {
 
-  /** Utility backing store. */
-  private final OlmUtility instance =
-      Utils.initialize(OlmLibrary::olm_utility, OlmLibrary::olm_utility_size);
+  // backing store
+  private final OlmUtility instance;
 
   private ObjectMapper objectMapper = new ObjectMapper();
 
   /** Creates a new Utility object. */
   public Utility() {
+    // initialize backing store
+    instance = Utils.initialize(OlmLibrary::olm_utility, OlmLibrary::olm_utility_size);
+
     // canonical JSON
     objectMapper.configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
   }

--- a/src/test/java/io/github/brevilo/jolm/AccountTest.java
+++ b/src/test/java/io/github/brevilo/jolm/AccountTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 Oliver Behnke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.brevilo.jolm;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import io.github.brevilo.jolm.model.IdentityKeys;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+@TestInstance(Lifecycle.PER_CLASS)
+class AccountTest {
+
+  Account account;
+
+  @BeforeAll
+  void setUp() throws Exception {
+    account = new Account();
+  }
+
+  @AfterAll
+  void tearDown() throws Exception {
+    account.clear();
+  }
+
+  @Test
+  void testIdentityKeys() throws Exception {
+    IdentityKeys keys = account.identityKeys();
+
+    assertNotNull(keys.getCurve25519());
+    assertFalse(keys.getCurve25519().isEmpty());
+
+    assertNotNull(keys.getEd25519());
+    assertFalse(keys.getEd25519().isEmpty());
+  }
+}


### PR DESCRIPTION
Implicitly initializing them might have caused the JNA Memory instances to be GCed prematurely

Fixes #4 